### PR TITLE
Add overlay and fade animation to search nav icon

### DIFF
--- a/app/assets/javascripts/effective_search/base.js
+++ b/app/assets/javascripts/effective_search/base.js
@@ -1,7 +1,31 @@
+$(document).on('show.bs.collapse', '#effective-search-icon-form', function () {
+  var $form = $(this);
+  $("#effective-search-overlay").addClass('active');
+
+  // Fade in form: wait for browser to paint opacity:0, then transition to 1
+  requestAnimationFrame(function() {
+    requestAnimationFrame(function() {
+      $form.css('opacity', '1');
+    });
+  });
+});
+
 $(document).on('shown.bs.collapse', '#effective-search-icon-form', function () {
+  $(this).css('opacity', '');
   $("#effective-search-input").focus();
 });
 
+$(document).on('hide.bs.collapse', '#effective-search-icon-form', function () {
+  $("#effective-search-overlay").removeClass('active');
+});
+
 $(document).on('hidden.bs.collapse', '#effective-search-icon-form', function () {
+  $(this).css('opacity', '');
   $("#effective-search-input").blur();
+});
+
+$(document).on('keydown', function (e) {
+  if (e.key === 'Escape' && $('#effective-search-icon-form').hasClass('show')) {
+    $('#effective-search-icon-form').collapse('hide');
+  }
 });

--- a/app/assets/stylesheets/effective_search/base.scss
+++ b/app/assets/stylesheets/effective_search/base.scss
@@ -62,13 +62,38 @@ div.effective-search {
   text-decoration: none;
 }
 
+#effective-search-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  // background-color: #f8f9fc;
+  opacity: 0;
+  z-index: 8999;
+  pointer-events: none;
+  transition: opacity 0.35s ease;
+
+  &.active {
+    opacity: 0.5;
+    pointer-events: auto;
+  }
+}
+
 #effective-search-icon-form {
-  position: absolute;
+  position: fixed;
   left: 0;
   top: 0;
   z-index: 9000;
   height: 90px;
   border-bottom: solid 1px;
+
+  &.collapsing {
+    height: 90px !important;
+    width: 100% !important;
+    opacity: 0;
+    transition: opacity 0.35s ease !important;
+  }
 }
 
 #effective-search-icon {

--- a/app/views/effective/search/_form_nav_icon.html.haml
+++ b/app/views/effective/search/_form_nav_icon.html.haml
@@ -1,11 +1,13 @@
 %li.nav-item.effective-search-nav-item.d-flex
-  #effective-search-icon-form.collapse.width.w-100.bg-dark.shadow-sm
+  #effective-search-icon-form.collapse.width.w-100.bg-primary.shadow-sm.rounded-0
     .d-flex.p-4
       = effective_form_with(scope: :q, model: EffectiveSearch.Search.new, method: :get, url: effective_search.search_path, layout: :inline, class: "w-100") do |f|
         = f.text_field :term, label: false, placeholder: 'Search', autofocus: false, id: "effective-search-input", class: "form-control-lg border-0 w-100"
 
       .nav-link.ml-auto.flex-shrink-1.text-white{"data-toggle":"collapse", "data-target":"#effective-search-icon-form", role: "button"}
         = icon('x', class: "big-1")
+
+  #effective-search-overlay.bg-primary{"data-toggle":"collapse", "data-target":"#effective-search-icon-form"}
 
   .nav-link#effective-search-icon.d-flex.align-items-center{"data-target":"#effective-search-icon-form", "data-toggle":"collapse"}
     = icon('search')


### PR DESCRIPTION
## Summary
- Add a semi-transparent overlay that covers the page behind the search form
- Add Escape key support to dismiss the search form
- Synchronize fade-in/fade-out animations for both the form and overlay using CSS transitions (0.35s ease)

## Test plan
- [ ] Click the search icon — form and overlay should both fade in together
- [ ] Press Escape — form and overlay should both fade out
- [ ] Click the overlay — form and overlay should both dismiss
- [ ] Click the X button — form and overlay should both dismiss

🤖 Generated with [Claude Code](https://claude.com/claude-code)